### PR TITLE
Fix escape codes for bash

### DIFF
--- a/color.d
+++ b/color.d
@@ -43,5 +43,5 @@ string zshEscape(string code)
 
 string bashEscape(string code)
 {
-	return `\[` ~ code ~ `\]`;
+	return "\001" ~ code ~ "\002";
 }


### PR DESCRIPTION
From http://stackoverflow.com/a/24840720/713961:

> You're entirely right. \001 and \002, aka RL_PROMPT_START_IGNORE and
> RL_PROMPT_END_IGNORE, are a poorly documented readline feature. Bash
> converts [..] to \001..\002 for Readline, but neglects to escape
> existing ones so that this implementation detail leaks through (and it's
> so useful that you can hardly call it a bug).
