### PR TITLE
Fix issue #12 branches with / in it are cut-off

### DIFF
--- a/git.d
+++ b/git.d
@@ -7,7 +7,7 @@ import std.path : baseName, buildPath, relativePath;
 import std.process; // : A whole lotta stuff
 import std.range : empty, front, back;
 import std.stdio : File;
-import std.string : startsWith, strip;
+import std.string : startsWith, strip, countchars, chompPrefix;
 
 import time;
 import vcs;
@@ -144,8 +144,12 @@ string getHead(string repoRoot, Duration allottedTime)
 
 	// If we're on a branch head, .git/HEAD will look like
 	// ref: refs/heads/<branch>
-	if (headSHA.startsWith("ref:"))
-		return headSHA.baseName;
+	if (headSHA.startsWith("ref:")) {
+		if (headSHA.countchars("/") == 2)
+			return headSHA.baseName;
+		else
+			return headSHA.chompPrefix("ref: refs/heads/");
+	}
 
 	// Otherwise let's go rummaging through the refs to find something
 	immutable refsPath = buildPath(repoRoot, ".git", "refs");


### PR DESCRIPTION
This fixes the cut off branch names when a branch has a / in the name.
Example: "dev/2.7.x" was cut off to "2.7.x".

Let me know what you think. 

I left the original logic intact in case there are only two / in the `ref:` line, but otherwise it will chomp off the whole `ref: refs/heads/` part and return everything after that. Not sure if this is the ideal solution, but it seems to work in this case.

PS: I installed this tool on our servers and my coworkers love it. Thanks again.
