### PR TITLE
filter out packed-refs lines that start with ^

### DIFF
--- a/git.d
+++ b/git.d
@@ -177,7 +177,8 @@ string getHead(string repoRoot, Duration allottedTime)
 	// We didn't find anything in remotes. Let's check packed-refs
 	auto packedRefs = File(buildPath(repoRoot, ".git", "packed-refs"))
 		.byLine
-		.filter!(l => !l.startsWith('#'));
+		.filter!(l => !l.startsWith('#'))
+		.filter!(l => !l.startsWith('^'));
 
 	foreach(line; packedRefs) {
 		// Each line is in the form


### PR DESCRIPTION
I was experiencing a crash in promptoglyph in one of my repos when in a detached HEAD state, it turns out I had some entries in my `.git/packed-refs` file that looked like this:

```
d3a7bc8686412f9b1dffb02068fdf4e1c9a83572 refs/tags/1.0
^37e88fd3b395da6d0234d19e7718b4cf2417e6de
5fa9b906c3bbd8a435ce996ecd59d14bbb63a31b refs/tags/1.1
^b32dafdf8497d852f57e3a3c09a7e20e59b4cb42
```

The lines that start with a `^` character were causing promptoglyph to crash.  This commit fixes it by simply filtering those lines out.  I'm not really sure what git uses them for, but they don't seem to match up to any symbolic refs so should be safe to disregard here.
